### PR TITLE
Spotify playlist challenge changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,11 +8,12 @@
 # Crash log files
 crash.log
 
-# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
-# .tfvars files are managed as part of configuration and so should be included in
-# version control.
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version 
+# control as they are data points which are potentially sensitive and subject 
+# to change depending on the environment.
 #
-# example.tfvars
+*.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in
@@ -27,3 +28,7 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,3 @@ resource "spotify_playlist" "playlist" {
     data.spotify_search_track.by_artist.tracks[2].id,
   ]
 }
-
-output "tracks" {
-  value = data.spotify_search_track.by_artist.tracks
-}

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ provider "spotify" {
 }
 
 data "spotify_search_track" "by_artist" {
-  artists = ["Dolly Parton"]
+  artist = "Dolly Parton"
   #  album = "Jolene"
   #  name  = "Early Morning Breeze"
 }

--- a/main.tf
+++ b/main.tf
@@ -28,3 +28,7 @@ resource "spotify_playlist" "playlist" {
     data.spotify_search_track.by_artist.tracks[2].id,
   ]
 }
+
+output "tracks" {
+  value = data.spotify_search_track.by_artist.tracks
+}

--- a/main.tf
+++ b/main.tf
@@ -7,12 +7,14 @@ terraform {
   }
 }
 
-variable "spotify_api_key" {
-  type = string
-}
-
 provider "spotify" {
   api_key = var.spotify_api_key
+}
+
+data "spotify_search_track" "by_artist" {
+  artists = ["Dolly Parton"]
+  #  album = "Jolene"
+  #  name  = "Early Morning Breeze"
 }
 
 resource "spotify_playlist" "playlist" {
@@ -25,14 +27,4 @@ resource "spotify_playlist" "playlist" {
     data.spotify_search_track.by_artist.tracks[1].id,
     data.spotify_search_track.by_artist.tracks[2].id,
   ]
-}
-
-data "spotify_search_track" "by_artist" {
-  artists = ["Dolly Parton"]
-  #  album = "Jolene"
-  #  name  = "Early Morning Breeze"
-}
-
-output "tracks" {
-  value = data.spotify_search_track.by_artist.tracks
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     spotify = {
-      version = "~> 0.1.5"
+      version = "~> 0.2.6"
       source  = "conradludgate/spotify"
     }
   }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,3 @@
+output "tracks" {
+  value = data.spotify_search_track.by_artist.tracks
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,3 @@
-output "tracks" {
-  value = data.spotify_search_track.by_artist.tracks
+output "playlist_url" {
+  value = "https://open.spotify.com/playlist/${spotify_playlist.playlist.id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,4 @@
 output "playlist_url" {
-  value = "https://open.spotify.com/playlist/${spotify_playlist.playlist.id}"
+  value       = "https://open.spotify.com/playlist/${spotify_playlist.playlist.id}"
+  description = "Visit this URL in your browser to listen to the playlist"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,3 @@
+variable "spotify_api_key" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,4 @@
 variable "spotify_api_key" {
-  type = string
+  type        = string
+  description = "Set this as the APIKey that the authorization proxy server outputs"
 }


### PR DESCRIPTION
1. The documentation on https://learn.hashicorp.com/tutorials/terraform/spotify-playlist doesn't appear to properly reflect the files in the main branch, for instance there are no output files.

2. I got this error when version 0.1.5 was pinned so I bumped it and ran terraform init --upgrade and it seems to work.
```
❯ terraform apply
╷
│ Error: could not perform search [[artist:"Dolly Parton"]]: Get "https://api.spotify.com/v1/search?limit=10&q=artist%3A%22Dolly+Parton%22&type=track": 404 page not found
│ 
│
│   with data.spotify_search_track.by_artist,
│   on main.tf line 30, in data "spotify_search_track" "by_artist":
│   30: data "spotify_search_track" "by_artist" {
```